### PR TITLE
Add build tests to Github Actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,10 @@ jobs:
 #          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
 #          cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
 #          architecture: x64 # optional, x64 or arm64
+      - run: flutter pub get
       - run: flutter test
+      - run: flutter build apk
+      - run: flutter build appbundle
 # todo: add integration tests
 #  integration-tests:
 #    runs-on: windows-latest


### PR DESCRIPTION
This should make sure our program is runnable at the very least.
Currently this is just the android build.

Tests are failing as I am waiting on #47, but it runs locally and the tests should start working once that PR is merged.