### PR TITLE
Refactor task views

### DIFF
--- a/lib/common/database.dart
+++ b/lib/common/database.dart
@@ -883,41 +883,7 @@ class DatabaseService {
     return getTasksDue(dateStart, nextMonth);
   }
 
-  /// Get weekly tasks as a single list
-  Future<List<Task>> fetchWeeklyTask({DateTime? weekStart}) async {
-    DateTime today = getDateOnly(weekStart ?? DateTime.now());
-    today = mostRecentMonday(today);
-    Map<DateTime, List<Task>> activeMap, delayedMap, completedMap;
-
-    // Fetch task maps for the specified week
-    (activeMap, delayedMap, completedMap) = await getTaskMapsWeek(today);
-    Map<DateTime, List<Task>> dueTasksMap = await getTasksDueWeek(today);
-
-    List<Task> allTasks = [];
-    for (int i = 0; i < 7; i++) {
-      DateTime newDay = getDateOnly(today, offsetDays: i);
-      allTasks += activeMap[newDay]!;
-      allTasks += delayedMap[newDay]!;
-      allTasks += completedMap[newDay]!;
-      allTasks += dueTasksMap[newDay]!;
-    }
-    // print('All tasks for the week: $allTasks');
-
-    return allTasks;
-  }
-
-  /// Get daily tasks for a day as a single list
-  /// returns a list of tasks
-  Future<List<Task>> fetchTodayTasks(DateTime selectedDate) async {
-    Map<DateTime, List<Task>> activeMap, delayedMap, completedMap;
-    (activeMap, delayedMap, completedMap) =
-        await getTaskMapsDay(selectedDate);
-
-    //active = activeMap;
-    final todayTasks = [...activeMap[selectedDate]!, ...delayedMap[selectedDate]!, ...completedMap[selectedDate]!];
-
-    return todayTasks;
-  }
+  ////////////////////////////////////////////////////
 
   // todo: figure out pagination support. from my findings, firestore has poor support for this when also doing queries, and this is only supported with third party services (there are libraries for 3rd parties though), which may not be free :(
   /// Perform a query on a user collection with a certain document key

--- a/lib/common/database.dart
+++ b/lib/common/database.dart
@@ -477,19 +477,16 @@ class DatabaseService {
 
   /// Returns a 3-tuple of List<Task>
   /// Each list has tasks that are either active, completed, or delayed in a time window
-  Future<(List<Task>, List<Task>, List<Task>)> getTaskMapsDay(
+  Future<
+      (
+        Map<DateTime, List<Task>>,
+        Map<DateTime, List<Task>>,
+        Map<DateTime, List<Task>>
+      )> getTaskMapsDay(
       DateTime dateStart) async {
     dateStart = getDateOnly(dateStart);
 
-    Map<DateTime, List<Task>> dayActiveMap, dayCompMap, dayDelayMap;
-    (dayActiveMap, dayCompMap, dayDelayMap) =
-        await getTaskMaps(dateStart, getDateOnly(dateStart, offsetDays: 1));
-
-    return (
-      dayActiveMap[dateStart] ?? [],
-      dayCompMap[dateStart] ?? [],
-      dayDelayMap[dateStart] ?? []
-    );
+    return await getTaskMaps(dateStart, getDateOnly(dateStart, offsetDays: 1));
   }
 
   /// Returns a 3-tuple of Maps<DateTime, List<Task>> where each map goes from 1 week from dateStart
@@ -912,12 +909,12 @@ class DatabaseService {
   /// Get daily tasks for a day as a single list
   /// returns a list of tasks
   Future<List<Task>> fetchTodayTasks(DateTime selectedDate) async {
-    List<Task> activeList, delayedList, completedList;
-    (activeList, delayedList, completedList) =
+    Map<DateTime, List<Task>> activeMap, delayedMap, completedMap;
+    (activeMap, delayedMap, completedMap) =
         await getTaskMapsDay(selectedDate);
 
     //active = activeMap;
-    final todayTasks = [...activeList, ...delayedList, ...completedList];
+    final todayTasks = [...activeMap[selectedDate]!, ...delayedMap[selectedDate]!, ...completedMap[selectedDate]!];
 
     return todayTasks;
   }

--- a/lib/common/localTaskDatabase.dart
+++ b/lib/common/localTaskDatabase.dart
@@ -1,0 +1,123 @@
+import 'package:planner/common/view/timeManagement.dart';
+import 'package:planner/models/task.dart';
+
+void _addOrExtendMap(Map<DateTime, List<Task>> map, Task task, DateTime key) {
+  if (map.containsKey(key)) {
+    map[key]!.add(task);
+  } else {
+    map[key] = [];
+    map[key]!.add(task);
+  }
+}
+
+class LocalTaskDatabase {
+  late Map<DateTime, List<Task>> active;
+  late Map<DateTime, List<Task>> delayed;
+  late Map<DateTime, List<Task>> completed;
+  late DateTime windowStart; // inclusive
+  late DateTime windowEnd; // non-inclusive
+
+  LocalTaskDatabase() {
+    active = {};
+    delayed = {};
+    completed = {};
+  }
+
+  void setFromTuple(
+      (
+        Map<DateTime, List<Task>>,
+        Map<DateTime, List<Task>>,
+        Map<DateTime, List<Task>>
+      ) tupleTaskMaps) {
+    active = tupleTaskMaps.$1;
+    completed = tupleTaskMaps.$2;
+    delayed = tupleTaskMaps.$3;
+  }
+
+  /// Add a new (just created from (+) button) task to db
+  void addNewTask(Task? taskMaybeNull) {
+    if (taskMaybeNull == null) {
+      return;
+    }
+    Task task = taskMaybeNull;
+    _addOrExtendMap(active, task, task.timeCurrent);
+  }
+
+  void moveDelayedTask(Task task, DateTime oldTaskDate) {
+    oldTaskDate = getDateOnly(oldTaskDate);
+    DateTime newTaskDate = task.timeCurrent;
+
+    active[oldTaskDate]!.remove(task);
+    for (int i = 0; i < daysBetween(oldTaskDate, newTaskDate); i++) {
+      DateTime dateToDelay = getDateOnly(oldTaskDate, offsetDays: i);
+      if (delayed[dateToDelay] != null) {
+        delayed[dateToDelay]!.add(task);
+      }
+    }
+    if (active[newTaskDate] != null) {
+      active[newTaskDate]!.add(task);
+    }
+  }
+
+  void deleteTask(Task task, DateTime deletionStart) {
+    DateTime deletionEnd = task.timeCurrent;
+    int daysToDelete = daysBetween(deletionStart, deletionEnd) + 1;
+
+    for (int i = 0; i < daysToDelete; i++) {
+      DateTime toDeleteTaskFrom = getDateOnly(deletionStart, offsetDays: i);
+      active[toDeleteTaskFrom]!.remove(task);
+      completed[toDeleteTaskFrom]!.remove(task);
+      delayed[toDeleteTaskFrom]!.remove(task);
+    }
+  }
+
+  List<Task> getTasksForDate(DateTime date) {
+    return (active[date] ?? []) +
+        (completed[date] ?? []) +
+        (delayed[date] ?? []);
+  }
+
+  void toggleCompleted(Task task, DateTime togglingStart) {
+    togglingStart = getDateOnly(togglingStart);
+    DateTime newTaskDate = task.timeCurrent;
+
+    for (int i = 0; i < daysBetween(togglingStart, newTaskDate) + 1; i++) {
+      // get the date of the current day
+      DateTime curr = getDateOnly(togglingStart, offsetDays: i);
+
+      // if the task was just completed
+      if (task.completed) {
+        // and if the task was active
+        if (active[curr]!.contains(task)) {
+          // then remove it from active and add it to complete
+          active[curr]!.remove(task);
+          completed[curr]!.add(task);
+        }
+
+        // or if the task was delayed
+        if (delayed[curr]!.contains(task)) {
+          // then remove it from delayed and add it to complete
+          delayed[curr]!.remove(task);
+          completed[curr]!.add(task);
+        }
+        // if the task was just uncompleted
+      } else {
+        // and if the task was complete
+        if (completed[curr]!.contains(task)) {
+          // then remove it from complete and add it to active
+          completed[curr]!.remove(task);
+          // if the task ws delayed
+          if (curr.isBefore(task.timeCurrent)) {
+            // then add it to the delayed list
+            delayed[curr]!.add(task);
+          }
+
+          if (curr.isAtSameMomentAs(task.timeCurrent)) {
+            // otherwise add it to the active list
+            active[curr]!.add(task);
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/common/localTaskDatabase.dart
+++ b/lib/common/localTaskDatabase.dart
@@ -50,13 +50,9 @@ class LocalTaskDatabase {
     active[oldTaskDate]!.remove(task);
     for (int i = 0; i < daysBetween(oldTaskDate, newTaskDate); i++) {
       DateTime dateToDelay = getDateOnly(oldTaskDate, offsetDays: i);
-      if (delayed[dateToDelay] != null) {
-        delayed[dateToDelay]!.add(task);
-      }
+      delayed[dateToDelay]?.add(task);
     }
-    if (active[newTaskDate] != null) {
-      active[newTaskDate]!.add(task);
-    }
+    active[newTaskDate]?.add(task);
   }
 
   void deleteTask(Task task, DateTime deletionStart) {
@@ -65,9 +61,9 @@ class LocalTaskDatabase {
 
     for (int i = 0; i < daysToDelete; i++) {
       DateTime toDeleteTaskFrom = getDateOnly(deletionStart, offsetDays: i);
-      active[toDeleteTaskFrom]!.remove(task);
-      completed[toDeleteTaskFrom]!.remove(task);
-      delayed[toDeleteTaskFrom]!.remove(task);
+      active[toDeleteTaskFrom]?.remove(task);
+      completed[toDeleteTaskFrom]?.remove(task);
+      delayed[toDeleteTaskFrom]?.remove(task);
     }
   }
 

--- a/lib/common/view/addTaskButton.dart
+++ b/lib/common/view/addTaskButton.dart
@@ -18,7 +18,7 @@ Future<Task?> addButtonForm(BuildContext context, state) async {
   TextEditingController locationController = TextEditingController();
   TextEditingController tagController = TextEditingController();
   DateTime? dueDate;
-  DateTime startTime = getDateOnly(DateTime.now());
+  DateTime startTime = getDateOnly(state.today);
   Completer<Task?> completer = Completer<Task?>();
   List<Tag> enteredTags = [];
   showDialog(

--- a/lib/common/view/addTaskButton.dart
+++ b/lib/common/view/addTaskButton.dart
@@ -10,45 +10,6 @@ import '../../common/view/tagPopup.dart';
 
 import 'flashError.dart';
 
-getAddTaskButton(state, context) {
-  return Align(
-    alignment: Alignment.bottomRight,
-    child: Padding(
-      padding:
-          const EdgeInsets.fromLTRB(0, 0, 20, 20), // Adjust the value as needed
-      child: ClipOval(
-        child: ElevatedButton(
-          onPressed: () async {
-            Task? newTask = await addButtonForm(context, state);
-            final newTodayTasks =
-                await state.db.fetchTodayTasks(state.selectedDay);
-            if (newTask != null) {
-              state.setState(() {
-                state.todayTasks.add(newTask);
-                state.fetchWeeklyTasks();
-              });
-              state.setState(() {
-                state._selectedDay = state.selectedDay;
-                state._focusedDay = state.selectedDay;
-                state.todayTasks = newTodayTasks;
-              });
-            }
-            state.setState(() {});
-          },
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.grey,
-            minimumSize: const Size(75, 75),
-          ),
-          child: const Icon(
-            Icons.add_outlined,
-            color: Colors.black,
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
 ///A function that asynchronously shows a dialog for adding a new task.
 Future<Task?> addButtonForm(BuildContext context, state) async {
   DatabaseService db = DatabaseService();

--- a/lib/common/view/topbar.dart
+++ b/lib/common/view/topbar.dart
@@ -168,7 +168,7 @@ AppBar _getTopBarDaily(bool forEvents, BuildContext context, state) {
                   } else {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (context) => TaskView(),
+                        builder: (context) => DailyTaskView(),
                       ),
                     );
                   }

--- a/lib/view/dailyTaskView.dart
+++ b/lib/view/dailyTaskView.dart
@@ -37,7 +37,6 @@ class TaskViewState extends State<DailyTaskView> {
   /// Performs asynchronous initialization for the widget.
   void asyncInitState() async {
     localDB.setFromTuple(await db.getTaskMapsDay(today));
-
     setState(() {});
   }
 

--- a/lib/view/dailyTaskView.dart
+++ b/lib/view/dailyTaskView.dart
@@ -11,9 +11,9 @@ import 'package:planner/view/weeklyTaskView.dart';
 import 'package:planner/view/taskCard.dart';
 
 class TaskView extends StatefulWidget {
-  late final DateTime initialDay;
+  late final DateTime selectedDay;
   TaskView({super.key, DateTime? dayOfDailyView}) {
-    initialDay = dayOfDailyView ?? DateTime.now();
+    selectedDay = dayOfDailyView ?? DateTime.now();
   }
   @override
   TaskViewState createState() => TaskViewState();
@@ -33,7 +33,7 @@ class TaskViewState extends State<TaskView> {
 
   /// Initializes the state of the widget.
   void initState() {
-    today = widget.initialDay;
+    today = widget.selectedDay;
     super.initState();
     asyncInitState();
   }

--- a/lib/view/dailyTaskView.dart
+++ b/lib/view/dailyTaskView.dart
@@ -153,7 +153,6 @@ class TaskViewState extends State<TaskView> {
             Expanded(
               child: getTodayTaskList(),
             ),
-            //getAddTaskButton(this, context),
             Align(
               alignment: Alignment.bottomRight,
               child: Padding(

--- a/lib/view/dailyTaskView.dart
+++ b/lib/view/dailyTaskView.dart
@@ -2,7 +2,6 @@ import 'package:planner/common/database.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:planner/common/view/timeManagement.dart';
 import 'package:planner/common/view/addTaskButton.dart';
 import 'package:planner/common/view/topbar.dart';
 import 'package:planner/models/task.dart';
@@ -12,7 +11,7 @@ import 'package:planner/view/weeklyTaskView.dart';
 import 'package:planner/view/taskCard.dart';
 
 class TaskView extends StatefulWidget {
-  late DateTime initialDay;
+  late final DateTime initialDay;
   TaskView({super.key, DateTime? dayOfDailyView}) {
     initialDay = dayOfDailyView ?? DateTime.now();
   }

--- a/lib/view/loginView.dart
+++ b/lib/view/loginView.dart
@@ -82,7 +82,7 @@ class LoginViewState extends State<LoginView> {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => TaskView(),
+          builder: (context) => DailyTaskView(),
         ),
       );
     });

--- a/lib/view/weeklyTaskView.dart
+++ b/lib/view/weeklyTaskView.dart
@@ -107,7 +107,6 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
     for (int i = 0; i < 7; i++) {
       DateTime currentDate = getDateOnly(monday, offsetDays: i);
       List<Task> tasksForDay = localDB.getTasksForDate(currentDate);
-      print(tasksForDay);
 
       dayWidgets.add(
         Column(

--- a/lib/view/weeklyTaskView.dart
+++ b/lib/view/weeklyTaskView.dart
@@ -91,11 +91,11 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
       return;
     }
 
-    setState(() {
-      today = selectedDate;
-    });
+    today = selectedDate;
     await setData();
-    generateScreen();
+    setState(() {
+      generateScreen();
+    });
   }
 
   /// A function that generates the screen for the next 7 days

--- a/lib/view/weeklyTaskView.dart
+++ b/lib/view/weeklyTaskView.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:planner/common/database.dart';
+import 'package:planner/common/localTaskDatabase.dart';
 import 'package:planner/common/view/timeManagement.dart';
 import 'package:planner/common/view/addTaskButton.dart';
 import 'package:planner/common/view/topbar.dart';
@@ -19,90 +21,40 @@ class WeeklyTaskView extends StatefulWidget {
 
 class WeeklyTaskViewState extends State<WeeklyTaskView> {
   final DatabaseService _db = DatabaseService();
+  late LocalTaskDatabase localDB;
   late DateTime today;
-  Map<DateTime, List<Task>> _active = {};
-  Map<DateTime, List<Task>> _complete = {};
-  Map<DateTime, List<Task>> _delay = {};
 
   /// Initializes the state of the widget
   @override
   void initState() {
     today = widget.selectedDay;
+    localDB = LocalTaskDatabase();
     super.initState();
-    setData();
+    asyncInitState();
+  }
+
+  /// Performs asynchronous initialization for the widget.
+  void asyncInitState() async {
+    await setData();
+    setState(() {});
   }
 
   /// Asynchronously fetches tasks for the current week
   Future<void> setData() async {
     DateTime monday = mostRecentMonday(today);
-    var taskMaps = await _db.getTaskMapsWeek(monday);
-    setState(() {
-      _active = taskMaps.$1;
-      _complete = taskMaps.$2;
-      _delay = taskMaps.$3;
-    });
+    localDB.setFromTuple(await _db.getTaskMapsWeek(monday));
   }
 
   void toggleCompleted(Task task) {
     DateTime monday = mostRecentMonday(today);
-    for (int i = 0; i < 7; i++) {
-      // get the date of the current day
-      DateTime curr = getDateOnly(monday, offsetDays: i);
-
-      // if the task was just completed
-      if (task.completed) {
-        // and if the task was active
-        if (_active[curr]!.contains(task)) {
-          // then remove it from active and add it to complete
-          _active[curr]!.remove(task);
-          _complete[curr]!.add(task);
-        }
-
-        // or if the task was delayed
-        if (_delay[curr]!.contains(task)) {
-          // then remove it from delayed and add it to complete
-          _delay[curr]!.remove(task);
-          _complete[curr]!.add(task);
-        }
-        // if the task was just uncompleted
-      } else {
-        // and if the task was complete
-        if (_complete[curr]!.contains(task)) {
-          // then remove it from complete and add it to active
-          _complete[curr]!.remove(task);
-          // if the task ws delayed
-          if (curr.isBefore(task.timeCurrent)) {
-            // then add it to the delayed list
-            _delay[curr]!.add(task);
-          }
-
-          if (curr.isAtSameMomentAs(task.timeCurrent)) {
-            // otherwise add it to the active list
-            _active[curr]!.add(task);
-          }
-        }
-      }
-    }
-    // then update the screen
+    localDB.toggleCompleted(task, monday);
     setState(() {
       generateScreen();
     });
   }
 
   void moveDelayedTask(Task task, DateTime oldTaskDate) async {
-    DateTime newTaskDate = task.timeCurrent;
-    _active[oldTaskDate]!.remove(task);
-    for (int i = 0; i < daysBetween(oldTaskDate, newTaskDate); i++) {
-      DateTime dateToDelay = getDateOnly(oldTaskDate, offsetDays: i);
-      if (_delay[dateToDelay] == null) {
-        _delay[dateToDelay] = [];
-      }
-      _delay[dateToDelay]!.add(task);
-    }
-    if (_active[newTaskDate] == null) {
-      _active[newTaskDate] = [];
-    }
-    _active[newTaskDate]!.add(task);
+    localDB.moveDelayedTask(task, oldTaskDate);
     setState(() {
       generateScreen();
     });
@@ -112,16 +64,7 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
     DateTime startOfWeek = mostRecentMonday(today);
     DateTime deletionStart =
         task.timeStart.isBefore(startOfWeek) ? startOfWeek : task.timeStart;
-    DateTime deletionEnd = task.timeCurrent;
-    int daysToDelete = daysBetween(deletionStart, deletionEnd) + 1;
-
-    for (int i = 0; i < daysToDelete; i++) {
-      DateTime toDeleteTaskFrom = getDateOnly(deletionStart, offsetDays: i);
-      _active[toDeleteTaskFrom]!.remove(task);
-      _complete[toDeleteTaskFrom]!.remove(task);
-      _delay[toDeleteTaskFrom]!.remove(task);
-    }
-
+    localDB.deleteTask(task, deletionStart);
     setState(() {
       generateScreen();
     });
@@ -130,11 +73,7 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
   /// Asynchronously transition to new WeeklyTaskView screen
   /// TODO: use something beside navigator to avoid the transition animation
   void loadWeek(DateTime newDateInWeek) async {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => WeeklyTaskView(dateInWeek: newDateInWeek),
-      ),
-    );
+    resetView(newDateInWeek);
   }
 
   /// Asynchronously loads tasks for the previous week and generates the screen
@@ -163,12 +102,12 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
   List<Widget> generateScreen() {
     List<Widget> dayWidgets = [];
     DateTime monday = mostRecentMonday(today);
+    var dateFormatter = DateFormat('EE').format;
 
     for (int i = 0; i < 7; i++) {
       DateTime currentDate = getDateOnly(monday, offsetDays: i);
-      List<Task> tasksForDay = (_active[currentDate] ?? []) +
-          (_complete[currentDate] ?? []) +
-          (_delay[currentDate] ?? []);
+      List<Task> tasksForDay = localDB.getTasksForDate(currentDate);
+      print(tasksForDay);
 
       dayWidgets.add(
         Column(
@@ -176,7 +115,7 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
             Padding(
               padding: const EdgeInsets.all(10),
               child: Text(
-                '${currentDate.month}/${currentDate.day}',
+                '${dateFormatter(currentDate)} ${currentDate.month}/${currentDate.day}',
                 style:
                     const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),

--- a/lib/view/weeklyTaskView.dart
+++ b/lib/view/weeklyTaskView.dart
@@ -174,11 +174,10 @@ class WeeklyTaskViewState extends State<WeeklyTaskView> {
               child: ElevatedButton(
                 onPressed: () async {
                   Task? newTask = await addButtonForm(context, this);
-                  if (newTask != null) {
-                    setState(() {
-                      setData();
-                    });
-                  }
+                  localDB.addNewTask(newTask);
+                  setState(() {
+                    generateScreen();
+                  });
                 },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.grey,

--- a/test/common/mapEquals.dart
+++ b/test/common/mapEquals.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:planner/models/task.dart';
+
+bool myMapEquals(Map<DateTime, List<Task>> m1, Map<DateTime, List<Task>> m2) {
+  if (m1.keys.length != m2.keys.length) {
+    return false;
+  }
+  for (DateTime key in m1.keys) {
+    if (!setEquals(m1[key]!.toSet(), m2[key]!.toSet())) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/localTaskDatabase_test.dart
+++ b/test/localTaskDatabase_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/common/localTaskDatabase.dart';
+import 'package:planner/models/task.dart';
+
+import 'common/mapEquals.dart';
+
+main() async {
+  LocalTaskDatabase_setFromTuple();
+}
+
+LocalTaskDatabase_setFromTuple() {
+  LocalTaskDatabase localDB = LocalTaskDatabase();
+  DateTime today = DateTime(2023, 11, 4);
+  Task task1 = Task(name: "test task 1");
+  Task task2 = Task(name: "test task 2");
+  Task task3 = Task(name: "test task 3");
+  Map<DateTime, List<Task>> active, delayed, completed;
+  active = {
+    today: [task1]
+  };
+  completed = {
+    today: [task2]
+  };
+  delayed = {
+    today: [task3]
+  };
+
+  group("Test that setting a tuple works as expected", () {
+    test("setting tuple", () {
+      localDB.setFromTuple((active, completed, delayed));
+
+      expect(myMapEquals(localDB.active, active), true);
+      expect(myMapEquals(localDB.completed, completed), true);
+      expect(myMapEquals(localDB.delayed, delayed), true);
+    });
+    test("getTodayTaskList", () {
+      List<Task> todayTasks = localDB.getTasksForDate(DateTime(2023, 11, 4));
+      expect(todayTasks, active[today]! + completed[today]! + delayed[today]!);
+    });
+  });
+}


### PR DESCRIPTION
Refactor for consistency and fewer extra variables.

For task daily/weekly/monthly view classes:
* __TaskView class now holds the initial selected date for the view
* __TaskViewState class now has 3 variables without the extras/duplicates from before: db, today, localDB
* "today" is the selected date on each view thats focused. For daily its the day thats focused, for weekly its the day of the week that new tasks will automatically go to, for monthly its date who's tasks are displayed. No more widget.selectedDay since we had to update both.
* start of the week/month is now calculated any time its needed via mostRecentMonday() or getMonthAsDateTime()
* No more todayTasks list or separate "active" "delay" "completed" anymore, use the localDB to store them in all views and get the lists of tasks as needed

Attempted extra refactor for all task view classes but not able to because daily/weekly/monthly extend their own class.

Things seem to work fine for me but not thoroughly tested. Recommend deeper testing and automated widget tests.